### PR TITLE
refactor: 서버컴포넌트 구성 방식 변경

### DIFF
--- a/apps/lostark-hands-next/app/@component/daily-content-section-list.tsx
+++ b/apps/lostark-hands-next/app/@component/daily-content-section-list.tsx
@@ -1,14 +1,17 @@
-import { getCalendarApi } from '@/service/game-contents';
-import { calendarSelector } from '@/service/game-contents/selector';
+'use client';
 
 import DailyContentSection from '@/app/@component/daily-content-section';
 import { LabelLayoutSkeleton } from '@/client-component/label-layout';
 
-export const revalidate = 300;
+import type { TCalendarData } from './types';
 
-export const DailyContentSectionList = async () => {
-	const { daily } = calendarSelector(await getCalendarApi());
+interface IDailyContentSectionListProps {
+	data: TCalendarData;
+}
 
+export const DailyContentSectionList = ({
+	data: { daily }
+}: IDailyContentSectionListProps) => {
 	return (
 		<div className="space-y-[16px]">
 			{Object.values(daily).map((item) => (

--- a/apps/lostark-hands-next/app/@component/event.tsx
+++ b/apps/lostark-hands-next/app/@component/event.tsx
@@ -1,4 +1,6 @@
-import { getEventApi } from '@/service/news';
+'use client';
+
+import type { IEvent } from '@/service/news/types';
 
 import {
 	LabelLayout,
@@ -9,11 +11,11 @@ import {
 	ThumbnailPostSkeleton
 } from '@/client-component/thumbnail-post';
 
-export const revalidate = 300;
+interface IEventProps {
+	data: IEvent[] | null;
+}
 
-export const Event = async () => {
-	const data = await getEventApi();
-
+export const Event = ({ data }: IEventProps) => {
 	return (
 		<LabelLayout
 			as="section"

--- a/apps/lostark-hands-next/app/@component/notice.tsx
+++ b/apps/lostark-hands-next/app/@component/notice.tsx
@@ -1,4 +1,5 @@
-import { getNoticeApi } from '@/service/news';
+'use client';
+
 import type { INotice } from '@/service/news/types';
 
 import {
@@ -10,14 +11,11 @@ import {
 	MessagePostSkeleton
 } from '@/client-component/message-post';
 
-export const revalidate = 300;
+interface INoticeProps {
+	data: (INotice[] | null)[];
+}
 
-export const Notice = async () => {
-	const [noticeData, storeData] = await Promise.all([
-		getNoticeApi('공지'),
-		getNoticeApi('상점')
-	]);
-
+export const Notice = ({ data: [noticeData, storeData] }: INoticeProps) => {
 	const noticeList = Array.from(
 		[...(noticeData ?? []), ...(storeData ?? [])].reduce((prev, cur) => {
 			const noticeType = cur.title.includes('업데이트') ? '업데이트' : cur.type;

--- a/apps/lostark-hands-next/app/@component/procyon-compass-section-list.tsx
+++ b/apps/lostark-hands-next/app/@component/procyon-compass-section-list.tsx
@@ -1,14 +1,17 @@
-import { getCalendarApi } from '@/service/game-contents';
-import { calendarSelector } from '@/service/game-contents/selector';
+'use client';
 
 import ProcyonCompassSection from '@/app/@component/procyon-compass-section';
 import { LabelLayoutSkeleton } from '@/client-component/label-layout';
 
-export const revalidate = 300;
+import type { TCalendarData } from './types';
 
-export const ProcyonCompassSectionList = async () => {
-	const { procyon } = calendarSelector(await getCalendarApi());
+interface IProcyonCompassSectionListProps {
+	data: TCalendarData;
+}
 
+export const ProcyonCompassSectionList = ({
+	data: { procyon }
+}: IProcyonCompassSectionListProps) => {
 	return (
 		<section className="grid gap-[16px] md:grid-cols-3">
 			{Object.values(procyon).map((item) => (

--- a/apps/lostark-hands-next/app/@component/types.ts
+++ b/apps/lostark-hands-next/app/@component/types.ts
@@ -1,8 +1,11 @@
+import type { calendarSelector } from '@/service/game-contents/selector';
 import type { ICalendar } from '@/service/game-contents/types';
 
 import type { convertCalendarData } from '@/util/calendar';
 
 export type TCalendarItem = ReturnType<typeof convertCalendarData>[0];
+
+export type TCalendarData = ReturnType<typeof calendarSelector>;
 
 export interface ICalenderContetProps {
 	title: string;

--- a/apps/lostark-hands-next/app/markets/@component/index.tsx
+++ b/apps/lostark-hands-next/app/markets/@component/index.tsx
@@ -13,12 +13,12 @@ import useClientRendered from '@/hook/use-client-rendered';
 import List from '@/app/markets/@component/list';
 
 interface IMarketsProps {
-	options: IOptions;
+	data: IOptions;
 }
 
-const Markets = ({ options }: IMarketsProps) => {
+const Markets = ({ data }: IMarketsProps) => {
 	const isClientRendered = useClientRendered();
-	const { filter, onOpenFilter } = useMarketsFilter(options);
+	const { filter, onOpenFilter } = useMarketsFilter(data);
 
 	return (
 		<div>

--- a/apps/lostark-hands-next/app/markets/page.tsx
+++ b/apps/lostark-hands-next/app/markets/page.tsx
@@ -1,22 +1,16 @@
-import { Suspense } from 'react';
-
 import ServerWrapper from '@/app/server-wrapper';
 
 import { getOptionsApi } from '@/service/markets';
 
 import Markets from '@/app/markets/@component';
 
-export const revalidate = 300;
-
 const Page = () => {
 	return (
 		<div className="space-y-[16px] px-[16px] pb-[16px]">
-			<Suspense>
-				<ServerWrapper
-					apiPromise={getOptionsApi()}
-					render={(data) => <Markets options={data} />}
-				/>
-			</Suspense>
+			<ServerWrapper
+				apiPromise={getOptionsApi()}
+				render={Markets}
+			/>
 		</div>
 	);
 };

--- a/apps/lostark-hands-next/app/page.tsx
+++ b/apps/lostark-hands-next/app/page.tsx
@@ -1,5 +1,6 @@
-/* eslint-disable max-len */
-import { Suspense } from 'react';
+import { getCalendarApi } from '@/service/game-contents';
+import { calendarSelector } from '@/service/game-contents/selector';
+import { getEventApi, getNoticeApi } from '@/service/news';
 
 import {
 	DailyContentSectionList,
@@ -13,44 +14,33 @@ import {
 	ProcyonCompassSectionListSkeleton
 } from '@/app/@component/procyon-compass-section-list';
 
-/**
- * build, cache 관련
- * {@link https://nextjs.org/docs/app/building-your-application/caching}
- *   --> 캐시도 단계가 있어보임. 경로 페이지에 대한 캐싱, , 데이터에 대한 캐싱 세분화
- *      - api 요청에 대한 캐싱: 동일 경로에 대한 api 요청은 중복되어있다면 한번만 요청하도록 함
- *   --> 그런데.. 이런 api 경로에 대한 캐싱같은것들 axios같은 서브파티를 쓰면 page에 segment 쓰는 방식으로밖에 방법이 없어보이는데 동일하게 적용 되는걸까..?
- *
- * fetch 관련 / 위처럼 page segment로 캐시, 혹은 재검증 값을 부여하거나 fetch를 쓰거나.. 인데, fetch가 뭔가 더 각 캐시 방식별로 디테일하게 잡아줄 수 있어보임
- * {@link https://nextjs.org/docs/app/api-reference/functions/fetch}
- *
- * cache time 5min isr 주기적으로 재빌드. 재검증되는 페이지들은 정적페이지로 간주되는듯
- *   --> {@link https://nextjs.org/docs/app/building-your-application/rendering/server-components#static-rendering-default}
- * {@link https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#revalidate}
- * {@link https://nextjs.org/docs/app/building-your-application/rendering/server-components#switching-to-dynamic-rendering}
- * 위 링크의 테이블을 보면 이해 좀 됨. 동적기능의 여부 + 데이터캐시 여부 = 해당 경로를 정적으로 생성할지 동적으로 생성할지
- * force-cache 유사 ssg
- * no-store 유사 ssr
- *
- * STREAMING RENDER
- */
+import ServerWrapper from './server-wrapper';
 
-export const revalidate = 300;
-
-const Page = async () => {
+const Page = () => {
 	return (
 		<div className="space-y-[16px] px-[16px] pb-[16px]">
-			<Suspense fallback={<ProcyonCompassSectionListSkeleton />}>
-				<ProcyonCompassSectionList />
-			</Suspense>
-			<Suspense fallback={<EventSkeleton />}>
-				<Event />
-			</Suspense>
-			<Suspense fallback={<NoticeSkeleton />}>
-				<Notice />
-			</Suspense>
-			<Suspense fallback={<DailyContentSectionListSkeleton />}>
-				<DailyContentSectionList />
-			</Suspense>
+			<ServerWrapper
+				fallback={<ProcyonCompassSectionListSkeleton />}
+				apiPromise={getCalendarApi()}
+				selector={calendarSelector}
+				render={ProcyonCompassSectionList}
+			/>
+			<ServerWrapper
+				fallback={<EventSkeleton />}
+				apiPromise={getEventApi()}
+				render={Event}
+			/>
+			<ServerWrapper
+				fallback={<NoticeSkeleton />}
+				apiPromise={Promise.all([getNoticeApi('공지'), getNoticeApi('상점')])}
+				render={Notice}
+			/>
+			<ServerWrapper
+				fallback={<DailyContentSectionListSkeleton />}
+				apiPromise={getCalendarApi()}
+				selector={calendarSelector}
+				render={DailyContentSectionList}
+			/>
 			<NotificationButton />
 		</div>
 	);

--- a/apps/lostark-hands-next/app/server-wrapper.tsx
+++ b/apps/lostark-hands-next/app/server-wrapper.tsx
@@ -1,35 +1,75 @@
-import type { ReactElement } from 'react';
+/* eslint-disable max-len */
 
-interface IServerWrapperProps<BasicReturnType> {
-	apiPromise: Promise<BasicReturnType>;
+import type { ComponentType } from 'react';
+import { type ReactElement, Suspense } from 'react';
+
+interface IServerWrapperProps<T> {
+	apiPromise: Promise<T>;
+	fallback?: ReactElement;
 }
 
-type TConditional<BasicReturnType, SelectorReturnType> =
+type TConditional<T, U> =
 	| {
-			render: (props: SelectorReturnType) => ReactElement | null;
-			selector: (props: BasicReturnType) => SelectorReturnType;
+			render: ComponentType<{ data: U }>;
+			selector: (props: T) => U;
 	  }
 	| {
-			render: (props: BasicReturnType) => ReactElement | null;
+			render: ComponentType<{ data: Awaited<T> }>;
 			selector?: undefined;
 	  };
 
 /**
- * streaming 혹은, ppr 지원 시 Suspense로 감싸야 할 경우 사용될 서버 컴포넌트
+ * build, cache 관련
+ * {@link https://nextjs.org/docs/app/building-your-application/caching}
+ *   --> 캐시도 단계가 있어보임. 경로 페이지에 대한 캐싱, , 데이터에 대한 캐싱 세분화
+ *      - api 요청에 대한 캐싱: 동일 경로에 대한 api 요청은 중복되어있다면 한번만 요청하도록 함
+ *   --> 그런데.. 이런 api 경로에 대한 캐싱같은것들 axios같은 서브파티를 쓰면 page에 segment 쓰는 방식으로밖에 방법이 없어보이는데 동일하게 적용 되는걸까..?
+ *
+ * fetch 관련 / 위처럼 page segment로 캐시, 혹은 재검증 값을 부여하거나 fetch를 쓰거나.. 인데, fetch가 뭔가 더 각 캐시 방식별로 디테일하게 잡아줄 수 있어보임
+ * {@link https://nextjs.org/docs/app/api-reference/functions/fetch}
+ *
+ * cache time 5min isr 주기적으로 재빌드. 재검증되는 페이지들은 정적페이지로 간주되는듯
+ *   --> {@link https://nextjs.org/docs/app/building-your-application/rendering/server-components#static-rendering-default}
+ * {@link https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#revalidate}
+ * {@link https://nextjs.org/docs/app/building-your-application/rendering/server-components#switching-to-dynamic-rendering}
+ * 위 링크의 테이블을 보면 이해 좀 됨. 동적기능의 여부 + 데이터캐시 여부 = 해당 경로를 정적으로 생성할지 동적으로 생성할지
+ * force-cache 유사 ssg
+ * no-store 유사 ssr
+ *
+ * STREAMING RENDER
  */
-const ServerWrapper = async <BasicReturnType, SelectorReturnType>({
+
+export const revalidate = 300;
+
+/**
+ * streaming 혹은, ppr 지원 시 Suspense로 감싸야 할 경우 사용될 서버 컴포넌트
+ * @param apiPromise Promise<dataType>
+ * @param fallback Suspense fallback
+ * @param render RenderComponent<{data: dataType | selectorReturnType}>
+ * @param selector dataSelector
+ */
+const ServerWrapper = async <T, U>({
 	apiPromise,
-	selector,
-	render
-}: IServerWrapperProps<BasicReturnType> &
-	TConditional<BasicReturnType, SelectorReturnType>) => {
-	const data = await apiPromise;
+	fallback,
+	render: Component,
+	selector
+}: IServerWrapperProps<T> & TConditional<T, U>) => {
+	const InnerComponent = async () => {
+		const data = await apiPromise;
 
-	if (typeof selector === 'undefined') {
-		return render(data);
-	}
+		return (
+			<>
+				{!selector && <Component data={data} />}
+				{selector && <Component data={selector(data)} />}
+			</>
+		);
+	};
 
-	return render(selector(data));
+	return (
+		<Suspense fallback={fallback}>
+			<InnerComponent />
+		</Suspense>
+	);
 };
 
 export default ServerWrapper;

--- a/apps/lostark-hands-next/app/user-info/[name]/@component/card-set.tsx
+++ b/apps/lostark-hands-next/app/user-info/[name]/@component/card-set.tsx
@@ -19,8 +19,10 @@ import { CDN_URL } from '@/constant';
 import type { TGrade } from '@/type';
 
 interface ICardSetProps {
-	cards: (ICard | null)[];
-	effects: ICardEffect[] | null;
+	data: {
+		cards: (ICard | null)[];
+		effects: ICardEffect[] | null;
+	};
 }
 
 const cardOutline: Record<TGrade, number> = {
@@ -34,7 +36,7 @@ const cardOutline: Record<TGrade, number> = {
 	에스더: 7
 };
 
-export const CardSet = ({ cards, effects }: ICardSetProps) => {
+export const CardSet = ({ data: { cards, effects } }: ICardSetProps) => {
 	const { onOpenModal } = useModalDispatch();
 
 	const handleOpenCardEffectModal = () => {

--- a/apps/lostark-hands-next/app/user-info/[name]/@component/engraves.tsx
+++ b/apps/lostark-hands-next/app/user-info/[name]/@component/engraves.tsx
@@ -14,10 +14,8 @@ import Skeleton from '@/client-component/skeleton';
 import { CDN_URL } from '@/constant';
 import ENGRAVE_IMGAE from '@/constant/engrave';
 
-import type { ToCamelKey } from '@/type';
-
 interface IEngravesProps {
-	data?: ToCamelKey<IEffect[]>;
+	data?: IEffect[] | null;
 }
 
 const engravePointColor: Record<number, string> = {

--- a/apps/lostark-hands-next/app/user-info/[name]/@component/profile.tsx
+++ b/apps/lostark-hands-next/app/user-info/[name]/@component/profile.tsx
@@ -9,7 +9,7 @@ import Label from '@/client-component/label';
 import Skeleton from '@/client-component/skeleton';
 
 interface IProfileProps {
-	data?: IArmoryProfile;
+	data?: IArmoryProfile | null;
 }
 
 export const Profile = ({ data }: IProfileProps) => {

--- a/apps/lostark-hands-next/app/user-info/[name]/@component/stats.tsx
+++ b/apps/lostark-hands-next/app/user-info/[name]/@component/stats.tsx
@@ -9,13 +9,17 @@ import Skeleton from '@/client-component/skeleton';
 import type { ToCamelKey } from '@/type';
 
 interface IStatsProps {
-	stats: ToCamelKey<IStat>[];
-	power: ToCamelKey<IStat>;
-	healty: ToCamelKey<IStat>;
+	data: {
+		stats: ToCamelKey<IStat>[];
+	};
 }
 
-export const Stats = ({ stats, power, healty }: IStatsProps) => {
+export const Stats = ({ data: { stats: initStats } }: IStatsProps) => {
 	const { onOpenModal } = useModalDispatch();
+
+	const stats = initStats.slice(0, 6);
+	const power = initStats[7];
+	const healty = initStats[6];
 
 	const handleOpenModal = () => {
 		if (!Number(power.value) || !Number(healty.value)) return;

--- a/apps/lostark-hands-next/app/user-info/[name]/@component/tendencies.tsx
+++ b/apps/lostark-hands-next/app/user-info/[name]/@component/tendencies.tsx
@@ -1,13 +1,19 @@
-import { getProfileInfoApi } from '@/service/armories';
-import { profileTooltipSelector } from '@/service/armories/selector';
+'use client';
 
 import Label from '@/client-component/label';
 import Skeleton from '@/client-component/skeleton';
 
-export const Tendencies = async ({ name }: { name: string }) => {
-	const data = await getProfileInfoApi(name);
-	const { tendencies } = profileTooltipSelector(data);
+interface ITendenceisProps {
+	data: {
+		tendencies: {
+			type: string;
+			point: number;
+			maxPoint: number;
+		}[];
+	};
+}
 
+export const Tendencies = ({ data: { tendencies } }: ITendenceisProps) => {
 	return (
 		<div className="grid grid-cols-2 gap-[6px] rounded-[6px] bg-main-20 p-[8px]">
 			{tendencies.map(({ type, point }) => (

--- a/apps/lostark-hands-next/app/user-info/[name]/avatar/page.tsx
+++ b/apps/lostark-hands-next/app/user-info/[name]/avatar/page.tsx
@@ -1,5 +1,3 @@
-import { Suspense } from 'react';
-
 import ServerWrapper from '@/app/server-wrapper';
 
 import { getAvatarApi } from '@/service/armories';
@@ -10,19 +8,14 @@ import {
 	AvatarSkeleton
 } from '@/app/user-info/[name]/avatar/@component';
 
-const AvatarRender = (data: ReturnType<typeof avatarSelector>) => (
-	<Avatar data={data} />
-);
-
 const Page = ({ params: { name } }: { params: { name: string } }) => {
 	return (
-		<Suspense fallback={<AvatarSkeleton />}>
-			<ServerWrapper
-				apiPromise={getAvatarApi(name)}
-				selector={avatarSelector}
-				render={AvatarRender}
-			/>
-		</Suspense>
+		<ServerWrapper
+			fallback={<AvatarSkeleton />}
+			apiPromise={getAvatarApi(name)}
+			selector={avatarSelector}
+			render={Avatar}
+		/>
 	);
 };
 

--- a/apps/lostark-hands-next/app/user-info/[name]/collection/@component/index.tsx
+++ b/apps/lostark-hands-next/app/user-info/[name]/collection/@component/index.tsx
@@ -48,7 +48,14 @@ const stickyNavStyle = cn(
 export const Collection = ({ data }: ICollectionProps) => {
 	const { isLg } = useResponsive();
 
-	const [selectCollect, setSelectCollect] = useState(data[0]);
+	const sortedData = data.map((item) => ({
+		...item,
+		collectiblePoints: item.collectiblePoints.sort((_, b) =>
+			b.maxPoint !== b.point ? 0 : -1
+		)
+	}));
+
+	const [selectCollect, setSelectCollect] = useState(sortedData[0]);
 
 	return (
 		<div className="w-full lg:flex">
@@ -58,7 +65,7 @@ export const Collection = ({ data }: ICollectionProps) => {
 				as="nav"
 				top={68}
 			>
-				{data.map((item) => (
+				{sortedData.map((item) => (
 					<div
 						className={cn(
 							'flex w-[130px] shrink-0 items-center',

--- a/apps/lostark-hands-next/app/user-info/[name]/collection/@component/medal.tsx
+++ b/apps/lostark-hands-next/app/user-info/[name]/collection/@component/medal.tsx
@@ -13,7 +13,7 @@ import {
 import { useModalDispatch } from '@/client-component/modal/provider';
 
 interface IMedalProps {
-	data: TParsedArmory<IArmoryEquipment>[];
+	data: { col: TParsedArmory<IArmoryEquipment>[] | null };
 }
 
 export const CollectionMedal = ({ data }: IMedalProps) => {
@@ -25,7 +25,7 @@ export const CollectionMedal = ({ data }: IMedalProps) => {
 			label="수집품 보상"
 		>
 			<div className="space-y-[8px]">
-				{data.map((item, idx) => (
+				{data.col?.map((item, idx) => (
 					<ArmoryCard
 						key={idx}
 						{...item}

--- a/apps/lostark-hands-next/app/user-info/[name]/collection/page.tsx
+++ b/apps/lostark-hands-next/app/user-info/[name]/collection/page.tsx
@@ -1,5 +1,3 @@
-import { Suspense } from 'react';
-
 import ServerWrapper from '@/app/server-wrapper';
 
 import { getCollectibleApi, getEquipmentApi } from '@/service/armories';
@@ -14,35 +12,20 @@ import {
 	CollectionMedalSkeleton
 } from '@/app/user-info/[name]/collection/@component/medal';
 
-const CollectionMedalRender = ({
-	col
-}: ReturnType<typeof equipmentSelector>) => <CollectionMedal data={col} />;
-
 const Page = ({ params: { name } }: { params: { name: string } }) => {
 	return (
 		<div className="flex flex-col-reverse lg:flex-row lg:space-x-[16px]">
-			<Suspense fallback={<CollectionSkeleton />}>
-				<ServerWrapper
-					apiPromise={getCollectibleApi(name)}
-					render={(data) => (
-						<Collection
-							data={data.map((item) => ({
-								...item,
-								collectiblePoints: item.collectiblePoints.sort((_, b) =>
-									b.maxPoint !== b.point ? 0 : -1
-								)
-							}))}
-						/>
-					)}
-				/>
-			</Suspense>
-			<Suspense fallback={<CollectionMedalSkeleton />}>
-				<ServerWrapper
-					apiPromise={getEquipmentApi(name)}
-					selector={equipmentSelector}
-					render={CollectionMedalRender}
-				/>
-			</Suspense>
+			<ServerWrapper
+				fallback={<CollectionSkeleton />}
+				apiPromise={getCollectibleApi(name)}
+				render={Collection}
+			/>
+			<ServerWrapper
+				fallback={<CollectionMedalSkeleton />}
+				apiPromise={getEquipmentApi(name)}
+				selector={equipmentSelector}
+				render={CollectionMedal}
+			/>
 		</div>
 	);
 };

--- a/apps/lostark-hands-next/app/user-info/[name]/layout.tsx
+++ b/apps/lostark-hands-next/app/user-info/[name]/layout.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, Suspense } from 'react';
+import { type ReactElement } from 'react';
 
 import ServerWrapper from '@/app/server-wrapper';
 
@@ -26,12 +26,11 @@ const Layout = ({
 }) => {
 	return (
 		<div>
-			<Suspense fallback={<ProfileSkeleton />}>
-				<ServerWrapper
-					apiPromise={getProfileInfoApi(name)}
-					render={(data) => <Profile data={data ?? undefined} />}
-				/>
-			</Suspense>
+			<ServerWrapper
+				fallback={<ProfileSkeleton />}
+				apiPromise={getProfileInfoApi(name)}
+				render={Profile}
+			/>
 			<div className="space-y-[12px] p-[16px]">
 				<TabList />
 				{children}

--- a/apps/lostark-hands-next/app/user-info/[name]/page.tsx
+++ b/apps/lostark-hands-next/app/user-info/[name]/page.tsx
@@ -1,5 +1,3 @@
-import { Suspense } from 'react';
-
 import ServerWrapper from '@/app/server-wrapper';
 
 import {
@@ -42,83 +40,54 @@ import {
 	TendenciesSkeleton
 } from '@/app/user-info/[name]/@component/tendencies';
 
-const StatsRender = ({ stats }: ReturnType<typeof profileTooltipSelector>) => (
-	<Stats
-		stats={stats.slice(0, 6)}
-		power={stats[7]}
-		healty={stats[6]}
-	/>
-);
-
-const EngravesRender = (data: ReturnType<typeof engraveSelector>) => (
-	<Engraves data={data ?? undefined} />
-);
-
-const EquipmentRender = (data: ReturnType<typeof equipmentSelector>) => (
-	<Equipment data={data} />
-);
-
-const CardSetRender = (data: ReturnType<typeof cardSelector>) => (
-	<CardSet {...data} />
-);
-
-const GemRender = (data: ReturnType<typeof gemSelector>) => <Gem data={data} />;
-
-const CombatSkillRender = (data: ReturnType<typeof skillSelector>) => (
-	<CombatSkill data={data} />
-);
-
 const Page = ({ params: { name } }: { params: { name: string } }) => {
 	return (
 		<div className="space-y-[16px] md:flex md:space-x-[16px] md:space-y-0">
 			<div className="w-full space-y-[12px] md:w-[200px] md:shrink-0">
-				<Suspense fallback={<StatsSkeleton />}>
-					<ServerWrapper
-						apiPromise={getProfileInfoApi(name)}
-						selector={profileTooltipSelector}
-						render={StatsRender}
-					/>
-				</Suspense>
-				<Suspense fallback={<TendenciesSkeleton />}>
-					<Tendencies name={name} />
-				</Suspense>
-				<Suspense fallback={<EngravesSkeleton />}>
-					<ServerWrapper
-						apiPromise={getEngravesInfoApi(name)}
-						selector={engraveSelector}
-						render={EngravesRender}
-					/>
-				</Suspense>
+				<ServerWrapper
+					fallback={<StatsSkeleton />}
+					apiPromise={getProfileInfoApi(name)}
+					selector={profileTooltipSelector}
+					render={Stats}
+				/>
+				<ServerWrapper
+					fallback={<TendenciesSkeleton />}
+					apiPromise={getProfileInfoApi(name)}
+					selector={profileTooltipSelector}
+					render={Tendencies}
+				/>
+				<ServerWrapper
+					fallback={<EngravesSkeleton />}
+					apiPromise={getEngravesInfoApi(name)}
+					selector={engraveSelector}
+					render={Engraves}
+				/>
 			</div>
 			<div className="w-full space-y-[16px] md:w-auto md:grow">
-				<Suspense fallback={<EquipmentSkeleton />}>
-					<ServerWrapper
-						apiPromise={getEquipmentApi(name)}
-						selector={equipmentSelector}
-						render={EquipmentRender}
-					/>
-				</Suspense>
-				<Suspense fallback={<CardSetSkeleton />}>
-					<ServerWrapper
-						apiPromise={getCardApi(name)}
-						selector={cardSelector}
-						render={CardSetRender}
-					/>
-				</Suspense>
-				<Suspense fallback={<GemSkeleton />}>
-					<ServerWrapper
-						apiPromise={getGemApi(name)}
-						selector={gemSelector}
-						render={GemRender}
-					/>
-				</Suspense>
-				<Suspense fallback={<CombatSkillSkeleton />}>
-					<ServerWrapper
-						apiPromise={getSkillApi(name)}
-						selector={skillSelector}
-						render={CombatSkillRender}
-					/>
-				</Suspense>
+				<ServerWrapper
+					fallback={<EquipmentSkeleton />}
+					apiPromise={getEquipmentApi(name)}
+					selector={equipmentSelector}
+					render={Equipment}
+				/>
+				<ServerWrapper
+					fallback={<CardSetSkeleton />}
+					apiPromise={getCardApi(name)}
+					selector={cardSelector}
+					render={CardSet}
+				/>
+				<ServerWrapper
+					fallback={<GemSkeleton />}
+					apiPromise={getGemApi(name)}
+					selector={gemSelector}
+					render={Gem}
+				/>
+				<ServerWrapper
+					fallback={<CombatSkillSkeleton />}
+					apiPromise={getSkillApi(name)}
+					selector={skillSelector}
+					render={CombatSkill}
+				/>
 			</div>
 		</div>
 	);

--- a/apps/lostark-hands-next/app/user-info/[name]/silblings/page.tsx
+++ b/apps/lostark-hands-next/app/user-info/[name]/silblings/page.tsx
@@ -1,5 +1,3 @@
-import { Suspense } from 'react';
-
 import ServerWrapper from '@/app/server-wrapper';
 
 import { getSilblingsInfoApi } from '@/service/characters';
@@ -10,19 +8,14 @@ import {
 	SilblingsSkeleton
 } from '@/app/user-info/[name]/silblings/@component';
 
-const SilblingsRender = (data: ReturnType<typeof sliblingListSelector>) => (
-	<Silblings data={data} />
-);
-
 const Page = ({ params: { name } }: { params: { name: string } }) => {
 	return (
-		<Suspense fallback={<SilblingsSkeleton />}>
-			<ServerWrapper
-				apiPromise={getSilblingsInfoApi(name)}
-				selector={sliblingListSelector}
-				render={SilblingsRender}
-			/>
-		</Suspense>
+		<ServerWrapper
+			fallback={<SilblingsSkeleton />}
+			apiPromise={getSilblingsInfoApi(name)}
+			selector={sliblingListSelector}
+			render={Silblings}
+		/>
 	);
 };
 

--- a/apps/lostark-hands-next/next.config.js
+++ b/apps/lostark-hands-next/next.config.js
@@ -7,7 +7,8 @@
 const withPWA = require('@ducanh2912/next-pwa').default({
 	dest: 'public',
 	cacheOnFrontEndNav: true,
-	aggressiveFrontEndNavCaching: true
+	aggressiveFrontEndNavCaching: true,
+	disable: process.env.NODE_ENV === 'development'
 });
 
 /**


### PR DESCRIPTION
## 📌 Work details
- ServerWrapper 컴포넌트 구조 변경
  - 내부에서 suspense까지 관리하도록 변경
  - render 함수를 전달하는것이 아닌, 컴포넌트 함수를 전달하고 data 속성으로 값을 전달하도록 변경
  - render되는 컴포넌트의 data 속성타입과, selector 혹은 fetch api의 응답 타입이 추론되도록 적용


## 📌 Notes
- 
